### PR TITLE
TrailDBEvent wrapper object, and parse_timestamps option.

### DIFF
--- a/spec/traildb_spec.cr
+++ b/spec/traildb_spec.cr
@@ -123,6 +123,24 @@ describe TrailDB do
     traildb.time_range[0].epoch.should eq 1
     traildb.time_range[1].epoch.should eq 3
   end
+
+  it "should not parse timestamps when option is false by id" do
+    traildb = TrailDB.new("testtrail.tdb")
+    traildb.parse_timestamp = false
+    trail = traildb[0]
+    events = trail.to_a
+    events.map { |event| event["time"] }.to_a.should eq [1, 2, 3]
+  end
+
+  it "should not parse timestamps when option is false when iterating" do
+    traildb = TrailDB.new("testtrail.tdb")
+    traildb.parse_timestamp = false
+    traildb.trails.each do |(uuid, trail)|
+      trail.each_with_index do |event, i|
+        event["time"].should eq i + 1
+      end
+    end
+  end
 end
 
 describe TrailDBEventFilter do

--- a/spec/traildb_spec.cr
+++ b/spec/traildb_spec.cr
@@ -35,8 +35,10 @@ describe TrailDB do
     trail.should be_a TrailDBEventIterator
 
     # Force evaluation of iterator
-    events = trail.to_a
+    events = trail.map { |event| event.to_h }.to_a
     events.size.should eq 3
+
+    puts events
 
     # Assert fields individually
     events[0]["field1"].should eq "a"
@@ -57,7 +59,7 @@ describe TrailDB do
     trail.should be_a TrailDBEventIterator
 
     # Force evaluation of iterator
-    events = trail.to_a
+    events = trail.map { |event| event.to_h }.to_a
 
     # Assert full array format
     events.should eq [
@@ -96,7 +98,7 @@ describe TrailDB do
 
   it "should have the correct fields" do
     traildb = TrailDB.new("testtrail")
-    traildb.fields.should eq ["time", "field1", "field2"]
+    traildb.fields.should eq ["field1", "field2"]
   end
 
   it "should have the correct uuids" do
@@ -129,7 +131,7 @@ describe TrailDB do
     traildb.parse_timestamp = false
     trail = traildb[0]
     events = trail.to_a
-    events.map { |event| event["time"] }.to_a.should eq [1, 2, 3]
+    events.map { |event| event.time }.to_a.should eq [1, 2, 3]
   end
 
   it "should not parse timestamps when option is false when iterating" do
@@ -137,7 +139,7 @@ describe TrailDB do
     traildb.parse_timestamp = false
     traildb.trails.each do |(uuid, trail)|
       trail.each_with_index do |event, i|
-        event["time"].should eq i + 1
+        event.time.should eq i + 1
       end
     end
   end
@@ -212,7 +214,7 @@ describe TrailDBConstructor do
     j = 1
     trail.each do |event|
       j.to_s.should eq event["field2"]
-      j.should eq event["time"].as(Time).epoch
+      j.should eq event.time.as(Time).epoch
       j += 1
     end
     j.should eq 6
@@ -234,8 +236,8 @@ describe TrailDBConstructor do
     traildb = cons.close
 
     traildb[0].each_with_index do |event, i|
-      event["time"].should be_a Time
-      event["time"].as(Time).should eq events[i][0]
+      event.time.should be_a Time
+      event.time.as(Time).should eq events[i][0]
     end
 
     traildb.time_range.should eq({events[0][0].to_utc, events[2][0].to_utc})
@@ -275,11 +277,11 @@ describe TrailDBConstructor do
     crumbs = traildb.trails.to_a.map { |(uuid, trail)| trail.to_a }
     trail = crumbs[0]
 
-    trail[0]["time"].as(Time).epoch.should eq 123
+    trail[0].time.as(Time).epoch.should eq 123
     trail[0]["field1"].should eq "a"
     trail[0]["field2"].should eq ""
 
-    trail[1]["time"].as(Time).epoch.should eq 124
+    trail[1].time.as(Time).epoch.should eq 124
     trail[1]["field1"].should eq "b"
     trail[1]["field2"].should eq "c"
   end
@@ -297,10 +299,10 @@ describe TrailDBConstructor do
     traildb.num_events.should eq 2
     trail = traildb.trails.to_a.map { |(uuid, trail)| trail.to_a }[0]
 
-    trail[0]["time"].as(Time).epoch.should eq 123
+    trail[0].time.as(Time).epoch.should eq 123
     trail[0]["field1"].should eq "foobarbaz"
 
-    trail[1]["time"].as(Time).epoch.should eq 124
+    trail[1].time.as(Time).epoch.should eq 124
     trail[1]["field1"].should eq "barquuxmoo"
 
     File.delete("testtrail2.tdb")

--- a/spec/traildb_spec.cr
+++ b/spec/traildb_spec.cr
@@ -38,8 +38,6 @@ describe TrailDB do
     events = trail.map { |event| event.to_h }.to_a
     events.size.should eq 3
 
-    puts events
-
     # Assert fields individually
     events[0]["field1"].should eq "a"
     events[1]["field1"].should eq "b"

--- a/src/traildb.cr
+++ b/src/traildb.cr
@@ -111,7 +111,7 @@ class TrailDBEvent
   def [](fieldish : TrailDBField) : String
     item_slice = Slice.new(@item, @event.value.num_items)
     field = @traildb.field(fieldish)
-    @traildb.get_item_value(item_slice[field])
+    @traildb.get_item_value(item_slice[field - 1])
   end
 
   # Return the full event as a hash
@@ -405,7 +405,7 @@ class TrailDB
     1.upto(@num_fields - 1).each do |field|
       fieldish = String.new(LibTrailDB.tdb_get_field_name(@db, field))
       @fields << fieldish
-      @field_map[fieldish] = (field - 1).to_u32
+      @field_map[fieldish] = field.to_u32
     end
 
     @buffer = Pointer(UInt64).malloc(2)


### PR DESCRIPTION
- Optionally parse timestamps into `Time` objects with `parse_timestamps`. Set to false to return a `UInt64`. (Fixes #3)
- Introduce the `TrailDBEvent` class, a wrapper for items in the event. Instead of returning a `Hash`, we return something that can be evaluated more lazily.  (Fixes #2)